### PR TITLE
Allow IPv6 to be utilized

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ resource "aws_security_group" "bastion" {
     to_port     = var.ssh_port
     protocol    = "tcp"
     cidr_blocks = var.ingress_cidr_blocks
+    ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,12 @@ variable "ingress_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "ingress_ipv6_cidr_blocks" {
+  type        = list(string)
+  description = "List of IPv6 CIDR ranges to allow ssh access at security group level. Defaults to ::/0"
+  default     = ["::/0"]
+}
+
 variable "egress_cidr_blocks" {
   type        = list(string)
   description = "List of CIDR ranges to allow outbound traffic at security group level. Defaults to 0.0.0.0/0"


### PR DESCRIPTION
# Description

Add ingress rule to bastion security group to allow connections from IPv6 addresses