### PR TITLE
Add support for different aws partitions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.44.0
+  rev: v1.45.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Update module versions to support v3 provider
+
+
+<a name="1.5.0"></a>
+## [1.5.0] - 2020-12-18
+
+- [On Demand] Support for on-demand instance lifecycle type. ([#8](https://github.com/umotif-public/terraform-aws-bastion/issues/8))
+- Update README.md
+
+
+<a name="1.4.2"></a>
+## [1.4.2] - 2020-11-09
+
+- Update module to remove 0.14 limit ([#7](https://github.com/umotif-public/terraform-aws-bastion/issues/7))
+
+
+<a name="1.4.1"></a>
+## [1.4.1] - 2020-08-05
+
+- Feature/v3 provider support ([#6](https://github.com/umotif-public/terraform-aws-bastion/issues/6))
 
 
 <a name="1.4.0"></a>
@@ -64,7 +82,10 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.4.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.5.0...HEAD
+[1.5.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.4.2...1.5.0
+[1.4.2]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.4.1...1.4.2
+[1.4.1]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/1.1.0...1.2.0

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This module will create Bastion Host/s which will make use of Launch Template an
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
+Terraform 0.13+. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
 ```hcl
 module "bastion" {
   source = "umotif-public/bastion/aws"
-  version = "~> 1.4.0"
+  version = "~> 2.0.0"
 
   name_prefix = "core-example"
 
@@ -37,10 +37,6 @@ module "bastion" {
 
 ![Basiton](bastion-arch.jpeg)
 
-## Assumptions
-
-Module is to be used with Terraform > 0.12.
-
 ## Examples
 
 * [Bastion Host](https://github.com/umotif-public/terraform-aws-bastion/tree/master/examples/core)
@@ -54,7 +50,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.45 |
 
 ## Providers
@@ -77,10 +73,10 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | asg\_scale\_up\_min\_size | Auto Scalling Group value for minimum capacity of bastion hosts. Scale up action. | `number` | `1` | no |
 | asg\_scale\_up\_recurrence | The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format. Scale up action. | `string` | `"0 9 * * MON-FRI"` | no |
 | availability\_zones | Availability zones for the default Ireland region. | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b",<br>  "eu-west-1c"<br>]</pre> | no |
+| aws\_partition | A Partition is a group of AWS Region and Service objects. You can use a partition to determine what services are available in a region, or what regions a service is available in. | `string` | `"public"` | no |
 | bastion\_instance\_types | Bastion instance types used for spot instances. | `list(string)` | <pre>[<br>  "t3.nano",<br>  "t3.micro",<br>  "t3.small",<br>  "t2.nano",<br>  "t2.micro",<br>  "t2.small"<br>]</pre> | no |
 | delete\_on\_termination | Whether the volume should be destroyed on instance termination. | `bool` | `true` | no |
 | desired\_capacity | Auto Scalling Group value for desired capacity of bastion hosts. | `number` | `1` | no |
-| on\_demand\_base\_capacity | Auto Scalling Group value for desired capacity for instance lifecycle type on-demand of bastion hosts. | `number` | `0` | no |
 | device\_name | The name of the device to mount. | `string` | `"/dev/xvda"` | no |
 | egress\_cidr\_blocks | List of CIDR ranges to allow outbound traffic at security group level. Defaults to 0.0.0.0/0 | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to allow outbound traffic at security group level. Defaults to ::/0 | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
@@ -93,6 +89,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | max\_size | Auto Scalling Group value for maximum capacity of bastion hosts. | `number` | `1` | no |
 | min\_size | Auto Scalling Group value for minimum capacity of bastion hosts. | `number` | `1` | no |
 | name\_prefix | A prefix used for naming resources. | `string` | n/a | yes |
+| on\_demand\_base\_capacity | Auto Scalling Group value for desired capacity for instance lifecycle type on-demand of bastion hosts. | `number` | `0` | no |
 | private\_subnets | Classless Inter-Domain Routing ranges for private subnets. | `list(string)` | `[]` | no |
 | public\_subnets | Classless Inter-Domain Routing ranges for public subnets. | `list(string)` | n/a | yes |
 | region | AWS region in which resources will get deployed. Defaults to Ireland. | `string` | `"eu-west-1"` | no |

--- a/data.tf
+++ b/data.tf
@@ -20,3 +20,14 @@ data "aws_ami" "amazon_linux" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "bastion_role_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = var.aws_partition == "china" ? ["ec2.amazonaws.com.cn"] : ["ec2.amazonaws.com"]
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -164,20 +164,7 @@ resource "aws_iam_role" "bastion" {
   name = "${var.name_prefix}-bastion-role"
   path = "/"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+  assume_role_policy = data.aws_iam_policy_document.bastion_role_assume_role_policy.json
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,15 @@ variable "volume_type" {
   description = "The type of volume. Can be `standard`, `gp2`, or `io1`."
   default     = "gp2"
 }
+
+variable "aws_partition" {
+  type    = string
+  default = "public"
+
+  description = "A Partition is a group of AWS Region and Service objects. You can use a partition to determine what services are available in a region, or what regions a service is available in."
+
+  validation {
+    condition     = contains(["public", "china"], var.aws_partition)
+    error_message = "Argument \"aws_partition\" must be either \"public\" or \"china\"."
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = ">= 2.45"


### PR DESCRIPTION
# Description

Following update form `2.0.0` release
- upgrade minimum terraform version to 0.13
- add support for different AWS partitions, currently supported are China and Public