### PR TITLE
Upgrade Amazon Linux AMI version to use 5.10 kernel version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.71.0
+  rev: v1.73.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- Removing unneeded variables
+- Upgrade Amazon Linux AMI version to use 5.10 kernal version
+
+
+<a name="2.3.0"></a>
+## [2.3.0] - 2022-05-12
+
 - Add documentation ([#18](https://github.com/umotif-public/terraform-aws-bastion/issues/18))
 - Allow setting time_zone for ASG schedules ([#17](https://github.com/umotif-public/terraform-aws-bastion/issues/17))
 
@@ -120,7 +127,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.2.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.0.3...2.1.0
 [2.0.3]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.0.2...2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+- Add documentation ([#18](https://github.com/umotif-public/terraform-aws-bastion/issues/18))
 - Allow setting time_zone for ASG schedules ([#17](https://github.com/umotif-public/terraform-aws-bastion/issues/17))
 
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0, < 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0, < 5.0.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "bastion" {
 
 ## Bastion Host Visual Architecture
 
-![Basiton](bastion-arch.jpeg)
+![Bastion](bastion-arch.jpeg)
 
 ## Examples
 
@@ -43,7 +43,7 @@ module "bastion" {
 
 ## Authors
 
-Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](https://www.linkedin.com/in/marcincuber/).
+Module managed by [uMotif](https://github.com/umotif-public).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -95,7 +95,7 @@ No modules.
 | <a name="input_asg_scale_up_min_size"></a> [asg\_scale\_up\_min\_size](#input\_asg\_scale\_up\_min\_size) | Auto Scalling Group value for minimum capacity of bastion hosts. Scale up action. | `number` | `1` | no |
 | <a name="input_asg_scale_up_recurrence"></a> [asg\_scale\_up\_recurrence](#input\_asg\_scale\_up\_recurrence) | The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format. Scale up action. | `string` | `"0 9 * * MON-FRI"` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the default Ireland region. | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b",<br>  "eu-west-1c"<br>]</pre> | no |
-| <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | Bastion instance types used for spot instances. | `list(string)` | <pre>[<br>  "t3.nano",<br>  "t3.micro",<br>  "t3.small",<br>  "t2.nano",<br>  "t2.micro",<br>  "t2.small"<br>]</pre> | no |
+| <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | Bastion instance types used for spot instances. | `list(string)` | <pre>[<br>  "t4g.nano",<br>  "t4g.micro",<br>  "t4g.small"<br>]</pre> | no |
 | <a name="input_delete_on_termination"></a> [delete\_on\_termination](#input\_delete\_on\_termination) | Whether the volume should be destroyed on instance termination. | `bool` | `true` | no |
 | <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity) | Auto Scalling Group value for desired capacity of bastion hosts. | `number` | `1` | no |
 | <a name="input_device_name"></a> [device\_name](#input\_device\_name) | The name of the device to mount. | `string` | `"/dev/xvda"` | no |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ No modules.
 | <a name="input_asg_scale_up_min_size"></a> [asg\_scale\_up\_min\_size](#input\_asg\_scale\_up\_min\_size) | Auto Scalling Group value for minimum capacity of bastion hosts. Scale up action. | `number` | `1` | no |
 | <a name="input_asg_scale_up_recurrence"></a> [asg\_scale\_up\_recurrence](#input\_asg\_scale\_up\_recurrence) | The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format. Scale up action. | `string` | `"0 9 * * MON-FRI"` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the default Ireland region. | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b",<br>  "eu-west-1c"<br>]</pre> | no |
-| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | [Deprecated] Variable will be removed in version `3.0.0`. A Partition is a group of AWS Region and Service objects. You can use a partition to determine what services are available in a region, or what regions a service is available in. | `string` | `"public"` | no |
 | <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | Bastion instance types used for spot instances. | `list(string)` | <pre>[<br>  "t3.nano",<br>  "t3.micro",<br>  "t3.small",<br>  "t2.nano",<br>  "t2.micro",<br>  "t2.small"<br>]</pre> | no |
 | <a name="input_delete_on_termination"></a> [delete\_on\_termination](#input\_delete\_on\_termination) | Whether the volume should be destroyed on instance termination. | `bool` | `true` | no |
 | <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity) | Auto Scalling Group value for desired capacity of bastion hosts. | `number` | `1` | no |
@@ -112,7 +111,6 @@ No modules.
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Auto Scalling Group value for minimum capacity of bastion hosts. | `number` | `1` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A prefix used for naming resources. | `string` | n/a | yes |
 | <a name="input_on_demand_base_capacity"></a> [on\_demand\_base\_capacity](#input\_on\_demand\_base\_capacity) | Auto Scalling Group value for desired capacity for instance lifecycle type on-demand of bastion hosts. | `number` | `0` | no |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Classless Inter-Domain Routing ranges for private subnets. | `list(string)` | `[]` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Classless Inter-Domain Routing ranges for public subnets. | `list(string)` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region in which resources will get deployed. Defaults to Ireland. | `string` | `"eu-west-1"` | no |
 | <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | SSH key used to connect to the bastion host | `string` | n/a | yes |

--- a/data.tf
+++ b/data.tf
@@ -8,9 +8,7 @@ data "aws_ami" "amazon_linux" {
   filter {
     name = "name"
 
-    values = [
-      "amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2",
-    ]
+    values = ["amzn2-ami-kernel-5.10-hvm-*-arm64-gp2"]
   }
 
   filter {

--- a/data.tf
+++ b/data.tf
@@ -9,7 +9,7 @@ data "aws_ami" "amazon_linux" {
     name = "name"
 
     values = [
-      "amzn2-ami-hvm-*-x86_64-gp2",
+      "amzn2-ami-kernel-5.10-hvm-*-x86_64-gp2",
     ]
   }
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -5,22 +5,14 @@ provider "aws" {
 #####
 # VPC and subnets
 #####
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.21.0"
+data "aws_vpc" "default" {
+  default = true
+}
 
-  name = "simple-vpc"
-
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  enable_nat_gateway = false
-
-  tags = {
-    Environment = "test"
+data "aws_subnets" "all" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
   }
 }
 
@@ -32,8 +24,8 @@ module "bastion" {
 
   name_prefix = "core-example"
 
-  vpc_id         = module.vpc.vpc_id
-  public_subnets = flatten([module.vpc.public_subnets])
+  vpc_id         = data.aws_vpc.default.id
+  public_subnets = flatten([data.aws_subnets.all.ids])
 
   hosted_zone_id = "Z1IY32BQNIYX17"
   ssh_key_name   = "eks-test"

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "availability_zones" {
 variable "bastion_instance_types" {
   type        = list(string)
   description = "Bastion instance types used for spot instances."
-  default     = ["t3.nano", "t3.micro", "t3.small", "t2.nano", "t2.micro", "t2.small"]
+  default     = ["t4g.nano", "t4g.micro", "t4g.small"]
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "vpc_id" {
   description = "VPC ID where bastion hosts and security groups will be created."
 }
 
-variable "private_subnets" {
-  type        = list(string)
-  description = "Classless Inter-Domain Routing ranges for private subnets."
-  default     = []
-}
-
 variable "public_subnets" {
   type        = list(string)
   description = "Classless Inter-Domain Routing ranges for public subnets."
@@ -213,18 +207,6 @@ variable "volume_type" {
   type        = string
   description = "The type of volume. Can be `standard`, `gp2`, or `io1`."
   default     = "gp2"
-}
-
-variable "aws_partition" {
-  type    = string
-  default = "public"
-
-  description = "[Deprecated] Variable will be removed in version `3.0.0`. A Partition is a group of AWS Region and Service objects. You can use a partition to determine what services are available in a region, or what regions a service is available in."
-
-  validation {
-    condition     = contains(["public", "china"], var.aws_partition)
-    error_message = "Argument \"aws_partition\" must be either \"public\" or \"china\"."
-  }
 }
 
 variable "time_zone" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.13.7"
+  required_version = ">= 1.0.11"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.0.0, < 5.0.0"
   }
 }


### PR DESCRIPTION
# Description

- Upgrade the Amazon Linux AMI version to use the 5.10 kernel version
- Upgrade minimum versions and documentation