### PR TITLE
DEVOPS-1761 Updated volume type for EBS volume for the instance to use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,9 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
-  - id: check-executables-have-shebangs
   - id: pretty-format-json
     args: ['--autofix', '--no-sort-keys', '--indent=2']
   - id: check-byte-order-marker
@@ -18,7 +17,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.73.0
+  rev: v1.77.1
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Removing unneeded variables
-- Upgrade Amazon Linux AMI version to use 5.10 kernal version
+- DEVOPS-1761 Updated volume type for EBS volume for the instance to use
+
+
+<a name="2.4.0"></a>
+## [2.4.0] - 2022-07-13
+
+- Upgrade Amazon Linux AMI version to use 5.10 kernel version ([#19](https://github.com/umotif-public/terraform-aws-bastion/issues/19))
 
 
 <a name="2.3.0"></a>
@@ -127,7 +132,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.3.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.4.0...HEAD
+[2.4.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/umotif-public/terraform-aws-bastion/compare/2.0.3...2.1.0

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ No modules.
 | [aws_launch_template.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bastion_role_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -94,7 +93,6 @@ No modules.
 | <a name="input_asg_scale_up_max_size"></a> [asg\_scale\_up\_max\_size](#input\_asg\_scale\_up\_max\_size) | Auto Scalling Group value for maximum capacity of bastion hosts. Scale up action. | `number` | `1` | no |
 | <a name="input_asg_scale_up_min_size"></a> [asg\_scale\_up\_min\_size](#input\_asg\_scale\_up\_min\_size) | Auto Scalling Group value for minimum capacity of bastion hosts. Scale up action. | `number` | `1` | no |
 | <a name="input_asg_scale_up_recurrence"></a> [asg\_scale\_up\_recurrence](#input\_asg\_scale\_up\_recurrence) | The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format. Scale up action. | `string` | `"0 9 * * MON-FRI"` | no |
-| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the default Ireland region. | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b",<br>  "eu-west-1c"<br>]</pre> | no |
 | <a name="input_bastion_instance_types"></a> [bastion\_instance\_types](#input\_bastion\_instance\_types) | Bastion instance types used for spot instances. | `list(string)` | <pre>[<br>  "t4g.nano",<br>  "t4g.micro",<br>  "t4g.small"<br>]</pre> | no |
 | <a name="input_delete_on_termination"></a> [delete\_on\_termination](#input\_delete\_on\_termination) | Whether the volume should be destroyed on instance termination. | `bool` | `true` | no |
 | <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity) | Auto Scalling Group value for desired capacity of bastion hosts. | `number` | `1` | no |
@@ -112,15 +110,13 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A prefix used for naming resources. | `string` | n/a | yes |
 | <a name="input_on_demand_base_capacity"></a> [on\_demand\_base\_capacity](#input\_on\_demand\_base\_capacity) | Auto Scalling Group value for desired capacity for instance lifecycle type on-demand of bastion hosts. | `number` | `0` | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Classless Inter-Domain Routing ranges for public subnets. | `list(string)` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region in which resources will get deployed. Defaults to Ireland. | `string` | `"eu-west-1"` | no |
 | <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | SSH key used to connect to the bastion host | `string` | n/a | yes |
-| <a name="input_ssh_port"></a> [ssh\_port](#input\_ssh\_port) | SSH port used to access a bastion host. | `number` | `22` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Default tags attached to all resources. | `map(string)` | <pre>{<br>  "ServiceType": "ceng-eks"<br>}</pre> | no |
 | <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, OldestLaunchTemplate, AllocationStrategy. | `list(string)` | <pre>[<br>  "OldestInstance"<br>]</pre> | no |
 | <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone) | Used for ASG Scale Up/Down. Valid values are the canonical names of the IANA time zones (such as Etc/GMT+9 or London/Europe) | `string` | `"Etc/UTC"` | no |
 | <a name="input_userdata_file_content"></a> [userdata\_file\_content](#input\_userdata\_file\_content) | The user data to provide when launching the instance. | `string` | `""` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | The size of the volume in gigabytes. | `number` | `20` | no |
-| <a name="input_volume_type"></a> [volume\_type](#input\_volume\_type) | The type of volume. Can be `standard`, `gp2`, or `io1`. | `string` | `"gp2"` | no |
+| <a name="input_volume_type"></a> [volume\_type](#input\_volume\_type) | The volume type. Can be one of standard, 'gp2', 'gp3', 'io1', 'io2', 'sc1' or 'st1'. | `string` | `"gp3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where bastion hosts and security groups will be created. | `string` | n/a | yes |
 
 ## Outputs

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,3 @@
-data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_ami" "amazon_linux" {

--- a/examples/core/versions.tf
+++ b/examples/core/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 1.0.11"
+
+  required_providers {
+    aws = ">= 4.0.0, < 5.0.0"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,18 +3,6 @@ variable "name_prefix" {
   type        = string
 }
 
-variable "region" {
-  type        = string
-  default     = "eu-west-1"
-  description = "AWS region in which resources will get deployed. Defaults to Ireland."
-}
-
-variable "availability_zones" {
-  type        = list(string)
-  default     = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  description = "Availability zones for the default Ireland region."
-}
-
 variable "bastion_instance_types" {
   type        = list(string)
   description = "Bastion instance types used for spot instances."
@@ -78,11 +66,6 @@ variable "min_size" {
   type        = number
   description = "Auto Scalling Group value for minimum capacity of bastion hosts."
   default     = 1
-}
-
-variable "ssh_port" {
-  description = "SSH port used to access a bastion host."
-  default     = 22
 }
 
 variable "ingress_cidr_blocks" {

--- a/variables.tf
+++ b/variables.tf
@@ -205,8 +205,8 @@ variable "encrypted" {
 
 variable "volume_type" {
   type        = string
-  description = "The type of volume. Can be `standard`, `gp2`, or `io1`."
-  default     = "gp2"
+  description = "The volume type. Can be one of standard, 'gp2', 'gp3', 'io1', 'io2', 'sc1' or 'st1'."
+  default     = "gp3"
 }
 
 variable "time_zone" {


### PR DESCRIPTION
# Description

This is a part of our ongoing commitment to ensuring our modules are up to date with the latest features and releases recommended by AWS.
- Setting the new default EBS volume type from gp2 to gp3
