### PR TITLE
Fixes README example to use public_subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "bastion" {
   name_prefix = "core-example"
 
   vpc_id         = "vpc-abasdasd132"
-  subnets        = ["subnet-abasdasd132123", "subnet-abasdasd132123132"]
+  public_subnets = ["subnet-abasdasd132123", "subnet-abasdasd132123132"]
 
   hosted_zone_id = "Z1IY32BQNIYX16"
   ssh_key_name   = "test"


### PR DESCRIPTION
  instead subnets, which is not an input

# Description

Please explain the changes you made here and link to any relevant issues.
